### PR TITLE
add display flags readouts to display module

### DIFF
--- a/module-display/src/main/java/dev/sebaubuntu/athena/modules/display/DisplayModule.kt
+++ b/module-display/src/main/java/dev/sebaubuntu/athena/modules/display/DisplayModule.kt
@@ -176,6 +176,31 @@ class DisplayModule(context: Context) : Module {
                     } else {
                         null
                     },
+                    Element.Item(
+                        name="is_flag_presentable",
+                        title=LocalizedString(R.string.display_is_flag_presentable),
+                        value=Value((flags and Display.FLAG_PRESENTATION != 0))
+                    ),
+                    Element.Item(
+                        name="is_flag_secure",
+                        title=LocalizedString(R.string.display_is_flag_secure),
+                        value=Value((flags and Display.FLAG_SECURE != 0))
+                    ),
+                    Element.Item(
+                        name="is_flag_secure",
+                        title=LocalizedString(R.string.display_is_flag_private),
+                        value=Value((flags and Display.FLAG_PRIVATE != 0))
+                    ),
+                    Element.Item(
+                        name="is_flag_supports_protected_buffers",
+                        title=LocalizedString(R.string.display_is_flag_supports_protected_buffers),
+                        value=Value((flags and Display.FLAG_SUPPORTS_PROTECTED_BUFFERS != 0))
+                    ),
+                    Element.Item(
+                        name="is_flag_round",
+                        title=LocalizedString(R.string.display_is_flag_round),
+                        value=Value((flags and Display.FLAG_ROUND != 0))
+                    ),
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                         Element.Item(
                             name = "is_wide_color_gamut",

--- a/module-display/src/main/res/values/strings.xml
+++ b/module-display/src/main/res/values/strings.xml
@@ -19,6 +19,11 @@
     <string name="display_connection_to_sink_type">Connection to sink type</string>
     <string name="display_is_valid">Is valid</string>
     <string name="display_is_hdr">Is HDR</string>
+    <string name="display_is_flag_presentable">Has Presentation Flag</string>
+    <string name="display_is_flag_secure">Has Secure Flag</string>
+    <string name="display_is_flag_private">Has Private Flag</string>
+    <string name="display_is_flag_round">Has Round Flag</string>
+    <string name="display_is_flag_supports_protected_buffers">Supports Protected Buffers</string>
     <string name="display_is_wide_color_gamut">Is wide color gamut</string>
     <string name="display_preferred_wcg_color_space">Preferred wide color gamut color space</string>
     <string name="display_is_minimal_post_processing_supported">Is minimal post processing supported</string>


### PR DESCRIPTION
This PR adds readouts for the five major flags that can be provided to displays - Presentation, Secure, Round, Supports_Protected_Buffers, Private . These are important for apps that try to use multiple displays, so I'd love if they were available here to help me diagnose issues in my work.